### PR TITLE
Enhance security and config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# AudioTO
+
+Plataforma em PHP para gestão de podcasts e conteúdos para Terapia Ocupacional.
+
+## Requisitos
+- PHP 8
+- MySQL
+
+## Configuração
+
+1. Copie o arquivo `db/config.php` e ajuste as variáveis de ambiente `DB_HOST`, `DB_NAME`, `DB_USER` e `DB_PASS` conforme sua base de dados.
+2. Para pagamentos, configure as variáveis `EFI_CLIENT_ID`, `EFI_CLIENT_SECRET`, `EFI_PIX_KEY`, `EFI_CERT_FILE` e `EFI_WEBHOOK_URL` utilizadas em `payments/config-efi.php`.
+3. Instale dependências do módulo de pagamentos:
+
+```bash
+cd payments
+composer install
+```
+
+## Segurança
+
+Algumas páginas administrativas agora utilizam tokens CSRF para proteger requisições POST. Certifique-se de manter a sessão do usuário ativa para que o token seja válido.
+

--- a/db/config.php
+++ b/db/config.php
@@ -2,10 +2,10 @@
 // db/config.php
 
 // Configurações do Banco de Dados
-define('DB_HOST', 'localhost');
-define('DB_NAME', 'u582136142_AudioTO');
-define('DB_USER', 'u582136142_AudioTO');
-define('DB_PASS', 'Aceleron0@'); // Mantenha esta informação segura!
+define('DB_HOST', getenv('DB_HOST') ?: 'localhost');
+define('DB_NAME', getenv('DB_NAME') ?: 'u582136142_AudioTO');
+define('DB_USER', getenv('DB_USER') ?: 'u582136142_AudioTO');
+define('DB_PASS', getenv('DB_PASS') ?: 'change_me'); // Mantenha esta informação segura!
 define('DB_CHARSET', 'utf8mb4');
 
 // Configurações da Aplicação (Exemplos)

--- a/payments/config-efi.php
+++ b/payments/config-efi.php
@@ -2,13 +2,13 @@
 // payments/config-efi.php
 
 // ATENÇÃO: Substitua pelos seus dados reais e coloque o nome do seu certificado.
-$efi_pix_client_id = "Client_Id_0147ac1a253abfb6c3fe9c1ba536ba4a73339e25";
-$efi_pix_client_secret = "Client_Secret_e5afab09140b72e791cd0f5b9c5826965139f808";
-$efi_pix_key = "d1ea4613-8ef1-40a8-a74e-7e83c6476891"; // Sua chave Pix (CPF, CNPJ, Email, Telefone ou EVP)
-$efi_cert_path_name = "producao-448246-AudioTO.p12"; // APENAS o nome do arquivo do certificado .p12
-$efi_pix_sandbox = false; // true para ambiente de homologação (testes), false para produção
+$efi_pix_client_id = getenv('EFI_CLIENT_ID') ?: '';
+$efi_pix_client_secret = getenv('EFI_CLIENT_SECRET') ?: '';
+$efi_pix_key = getenv('EFI_PIX_KEY') ?: ''; // Sua chave Pix (CPF, CNPJ, Email, Telefone ou EVP)
+$efi_cert_path_name = getenv('EFI_CERT_FILE') ?: 'certificado.p12';
+$efi_pix_sandbox = filter_var(getenv('EFI_PIX_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
 // ...
-$efi_pix_webhook_url = "https://audioto.com.br/payments/webhook_efi.php"; // Exemplo
+$efi_pix_webhook_url = getenv('EFI_WEBHOOK_URL') ?: 'https://example.com/webhook.php';
 // ...
 // Caminho para a pasta de certificados DENTRO da pasta 'payments'
 $certsPath = __DIR__ . "/certs/" . $efi_cert_path_name;

--- a/sessao/csrf.php
+++ b/sessao/csrf.php
@@ -1,0 +1,19 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function getCsrfToken(): string {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function verifyCsrfToken(?string $token): bool {
+    if (!$token) {
+        return false;
+    }
+    return hash_equals($_SESSION['csrf_token'] ?? '', $token);
+}
+


### PR DESCRIPTION
## Summary
- add simple CSRF helper and integrate token checks in admin pages
- load database and Pix config from environment variables
- document setup and security in new README

## Testing
- `php -v` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc1aff5ac8327bba29a5f9dea3747